### PR TITLE
add photo and category to list item

### DIFF
--- a/prisma/migrations/20250306001144_add_photo_url_to_list_item/migration.sql
+++ b/prisma/migrations/20250306001144_add_photo_url_to_list_item/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "ListItem" ADD COLUMN "photoUrl" TEXT NOT NULL;

--- a/prisma/migrations/20250306003328_add_category/migration.sql
+++ b/prisma/migrations/20250306003328_add_category/migration.sql
@@ -1,0 +1,7 @@
+CREATE TABLE "Category" (
+    "id" UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+    "name" VARCHAR(50) NOT NULL UNIQUE,
+    "createdAt" TIMESTAMPTZ DEFAULT NOW() NOT NULL,
+    "updatedAt" TIMESTAMPTZ DEFAULT NOW() NOT NULL,
+    "description" VARCHAR(255)
+);

--- a/prisma/migrations/20250306021617_add_categories/migration.sql
+++ b/prisma/migrations/20250306021617_add_categories/migration.sql
@@ -1,0 +1,6 @@
+INSERT INTO "Category" ("id", "name", "description", "createdAt", "updatedAt") VALUES
+(gen_random_uuid(), 'Vegetable', 'Fresh and organic vegetables', NOW(), NOW()),
+(gen_random_uuid(), 'Fruit', 'Sweet and nutritious fruits', NOW(), NOW()),
+(gen_random_uuid(), 'Dairy', 'Milk-based products and alternatives', NOW(), NOW()),
+(gen_random_uuid(), 'Meat', 'Various types of fresh and processed meat', NOW(), NOW()),
+(gen_random_uuid(), 'Grain', 'Whole grains, bread, and cereals', NOW(), NOW());

--- a/prisma/migrations/20250306021649_add_category_to_list_item/migration.sql
+++ b/prisma/migrations/20250306021649_add_category_to_list_item/migration.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "ListItem" 
+ADD COLUMN "categoryId" UUID NOT NULL, 
+ADD CONSTRAINT "fk_listitem_category"
+FOREIGN KEY ("categoryId") 
+REFERENCES "Category"("id") 
+ON DELETE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,9 +1,3 @@
-// This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
-
-// Looking for ways to speed up your queries, or scale easily with your serverless or edge functions?
-// Try Prisma Accelerate: https://pris.ly/cli/accelerate-init
-
 generator client {
   provider = "prisma-client-js"
 }
@@ -13,16 +7,25 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-
 model ListItem {
-  id        String   @id @default(uuid())
-  name      String
+  id          String   @id @default(uuid())
+  name        String
   description String?
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt  
-  authorId  String
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+  authorId    String
+  photoUrl    String
+  categoryId  String   @db.Uuid
+  Category    Category @relation(fields: [categoryId], references: [id], onDelete: Cascade, onUpdate: NoAction, map: "fk_listitem_category")
 
   @@index([authorId])
 }
 
-
+model Category {
+  id          String     @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  name        String     @unique @db.VarChar(50)
+  createdAt   DateTime   @default(now()) @db.Timestamptz(6)
+  updatedAt   DateTime   @default(now()) @db.Timestamptz(6)
+  description String?    @db.VarChar(255)
+  ListItem    ListItem[]
+}

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1,6 +1,7 @@
 'use server'
 
 import { createItem } from '@/lib/models/item'
+import { listCategories } from '@/lib/models/category'
 import { getCurrentAuthUser } from '@/lib/models/user'
 import { revalidatePath } from 'next/cache'
 
@@ -8,6 +9,12 @@ export const addItemAction = async (formData: FormData): Promise<void> => {
   const authUser = getCurrentAuthUser()
   const name = formData.get('name') as string
   const description = formData.get('description') as string
-  await createItem(authUser, name, description)
+  const photoUrl = formData.get('photoUrl') as string
+  const categoryId = formData.get('categoryId') as string
+  await createItem(authUser, name, description, photoUrl, categoryId)
   revalidatePath('/')
+}
+
+export const fetchCategories = async () => {
+  return await listCategories()
 }

--- a/src/app/api/category/route.ts
+++ b/src/app/api/category/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createCategory } from '@/lib/models/category'
+
+export async function POST(req: NextRequest) {
+  try {
+    // TODO (Improvement): require token and authenticate user 
+    const formData = await req.formData()
+    const name = formData.get('name') as string
+    const description = formData.get('description') as string
+
+    await createCategory(name, description)
+
+    return NextResponse.json({ success: true }, { status: 201 })
+  } catch (error) {
+    console.error("Error adding category:", error)
+    return NextResponse.json({ error: 'Failed to create category' }, { status: 500 })
+  }
+}

--- a/src/app/dashboard/item/[id]/page.tsx
+++ b/src/app/dashboard/item/[id]/page.tsx
@@ -1,24 +1,66 @@
 import { getItemDetails } from '@/lib/models/item'
 import { getCurrentAuthUser } from '@/lib/models/user'
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
-import { Box, Button, Typography } from '@mui/material'
+import { Box, Button, Card, CardContent, CardMedia, Typography, Divider } from '@mui/material'
 
 export default async function Page({ params }: { params: { id: string } }) {
   const authUser = getCurrentAuthUser()
   const itemDetails = await getItemDetails(authUser, params.id)
 
   return (
-    <Box>
-      <Button href={'/dashboard'} startIcon={<ArrowBackIcon />}>
+    <Box display="flex" flexDirection="column" alignItems="center">
+      <Button href={'/dashboard'} startIcon={<ArrowBackIcon />} sx={{ alignSelf: "flex-start", mb: 2 }}>
         Back to all items
       </Button>
+
       {itemDetails ? (
-        <>
-          <Typography variant="h4">{itemDetails.name}</Typography>
-          <Typography color={itemDetails.description ? 'text.primary' : 'text.secondary'}>
-            {itemDetails.description || 'No description'}
-          </Typography>
-        </>
+        <Card sx={{ maxWidth: 600, width: "100%", boxShadow: 3, borderRadius: 2 }}>
+          {itemDetails.photoUrl && (
+            <CardMedia
+              component="img"
+              image={itemDetails.photoUrl}
+              alt={itemDetails.name}
+              sx={{
+                width: "100%",      
+                height: "auto",      
+                maxHeight: 400,     
+                objectFit: "contain", 
+                borderTopLeftRadius: 8,
+                borderTopRightRadius: 8,
+              }}
+            />
+          )}
+
+          <CardContent>
+            {/* Name */}
+            <Typography variant="subtitle2" color="text.secondary">
+              Name
+            </Typography>
+            <Typography variant="h4" gutterBottom>
+              {itemDetails.name}
+            </Typography>
+
+            <Divider sx={{ my: 1 }} />
+
+            {/* Category */}
+            <Typography variant="subtitle2" color="text.secondary">
+              Category
+            </Typography>
+            <Typography variant="body1" color="text.primary" gutterBottom>
+              {itemDetails?.category || 'No category'}
+            </Typography>
+
+            <Divider sx={{ my: 1 }} />
+
+            {/* Description */}
+            <Typography variant="subtitle2" color="text.secondary">
+              Description
+            </Typography>
+            <Typography variant="body1" color={itemDetails.description ? 'text.primary' : 'text.secondary'}>
+              {itemDetails.description || 'No description'}
+            </Typography>
+          </CardContent>
+        </Card>
       ) : (
         <Typography color="text.secondary">Item not found</Typography>
       )}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,5 +1,6 @@
 import { AddItemButton } from '@/components/AddItemButton'
 import { listMyItems } from '@/lib/models/item'
+import { listCategories } from '@/lib/models/category'
 import { getCurrentAuthUser } from '@/lib/models/user'
 import { pluralize } from '@/lib/utils'
 import {
@@ -16,6 +17,7 @@ import {
 export default async function Home() {
   const authUser = getCurrentAuthUser()
   const items = await listMyItems(authUser)
+  const categories = await listCategories() 
 
   return (
     <Stack spacing={2} sx={{ maxWidth: 400 }}>
@@ -35,7 +37,7 @@ export default async function Home() {
           in your list
         </Typography>
 
-        <AddItemButton />
+        <AddItemButton categories={categories} />
       </Box>
       {items.length > 0 && (
         <Box

--- a/src/components/AddItemButton.tsx
+++ b/src/components/AddItemButton.tsx
@@ -9,23 +9,32 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
+  MenuItem,
+  Select,
   Stack,
   TextField,
 } from '@mui/material'
 import { useSnackbar } from 'notistack'
 import { useState } from 'react'
 
-export const AddItemButton = () => {
+// TODO (Cleanup): this should live somewhere else
+type Category = {
+  id: string
+  name: string
+  description: string | null
+}
+
+export const AddItemButton = ({ categories }: { categories: Category[] }) => {
   const { enqueueSnackbar } = useSnackbar()
   const [open, setOpen] = useState(false)
+  const [selectedCategory, setSelectedCategory] = useState("")
 
   const handleOpen = () => setOpen(true)
-  const handleClose = () => {
-    setOpen(false)
-  }
+  const handleClose = () => setOpen(false)
 
   const handleSubmit = async (formData: FormData) => {
     try {
+      formData.append("categoryId", selectedCategory) 
       await addItemAction(formData)
     } catch (error) {
       enqueueSnackbar(formatErrorMessage(error), { variant: 'error' })
@@ -46,6 +55,25 @@ export const AddItemButton = () => {
           <DialogContent>
             <Stack spacing={2} sx={{ my: 2 }}>
               <TextField name="name" label="Name" fullWidth />
+              <TextField name="photoUrl" label="Photo URL" fullWidth />
+              <div>
+                <Select
+                  value={selectedCategory}
+                  onChange={(event) => setSelectedCategory(event.target.value)}
+                  displayEmpty
+                  fullWidth
+                >
+                  <MenuItem value="" disabled>
+                    Choose a category
+                  </MenuItem>
+                  {categories.map((category) => (
+                    <MenuItem key={category.id} value={category.id}>
+                      {category.name} - {category.description || "No description"}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </div>
+
               <TextField
                 name="description"
                 label="Description"

--- a/src/lib/models/category.ts
+++ b/src/lib/models/category.ts
@@ -1,0 +1,68 @@
+import { z } from 'zod'
+import { fromError } from 'zod-validation-error'
+import prisma from '../prisma'
+
+type Category = {
+  id: string
+  name: string
+  createdAt: Date
+  updatedAt: Date
+  description: string | null
+}
+
+export const createCategory = async (name: string, description?: string): Promise<Category> => {
+  const schema = z.object({
+    name: z.string().trim().min(1),
+    createdAt: z.string().datetime(),
+    updatedAt: z.string().datetime(),
+    description: z.string().trim().optional(),
+  })
+
+  const now = new Date().toISOString()
+
+  const parse = schema.safeParse({
+    name: name,
+    createdAt: now,
+    updatedAt: now,
+    description: description,
+  })
+
+  if (!parse.success) {
+    throw fromError(parse.error)
+  }
+
+  const data = parse.data
+  const category = await prisma.category.create({
+    data: {
+      name: data.name,
+      createdAt: data.createdAt,
+      updatedAt: data.updatedAt,
+      description: data.description,
+    },
+  })
+
+  return {
+    id: category.id,
+    name: category.name,
+    createdAt: category.createdAt,
+    updatedAt: category.updatedAt,
+    description: category.description,
+  }
+}
+
+export const listCategories = async (limit: number = 20): Promise<Category[]> => {
+  const categories = await prisma.category.findMany({
+    orderBy: {
+      name: 'asc',
+    },
+    take: limit,
+  })
+
+  return categories.map((item) => ({
+    id: item.id,
+    name: item.name,
+    createdAt: item.createdAt,
+    updatedAt: item.updatedAt,
+    description: item.description,
+  }))
+}

--- a/src/lib/models/item.ts
+++ b/src/lib/models/item.ts
@@ -11,6 +11,8 @@ type ListItem = {
 type ListItemDetails = {
   id: string
   name: string
+  photoUrl: string
+  category: string
   description: string | null
 }
 
@@ -25,20 +27,35 @@ export const getItemDetails = async (
 ): Promise<ListItemDetails | null> => {
   const listItem = await prisma.listItem.findFirst({ where: { id, authorId: authUser.id } })
   if (!listItem) return null
-  return { id: listItem.id, name: listItem.name, description: listItem.description }
+
+  const category = await prisma.category.findFirst({ where: {id: listItem.categoryId}})
+  if (!category) return null
+  const displayCategory = `${category?.name}${category?.description ? ` - ${category.description}` : ''}`;
+
+  return {
+    id: listItem.id,
+    name: listItem.name,
+    photoUrl: listItem.photoUrl,
+    category: displayCategory,
+    description: listItem.description,
+  }
 }
 
 export const createItem = async (
   authUser: AuthUser,
   name: string,
   description: string,
+  photoUrl: string,
+  categoryId: string,
 ): Promise<ListItem> => {
   const schema = z.object({
     name: z.string().trim().min(1),
+    photoUrl: z.string().trim().url(),
+    categoryId: z.string().trim().uuid(),
     description: z.string().trim().optional(),
   })
 
-  const parse = schema.safeParse({ name, description })
+  const parse = schema.safeParse({ name, photoUrl, description, categoryId })
 
   if (!parse.success) {
     throw fromError(parse.error)
@@ -46,7 +63,13 @@ export const createItem = async (
 
   const data = parse.data
   const listItem = await prisma.listItem.create({
-    data: { name: data.name, description: data.description, authorId: authUser.id },
+    data: {
+      name: data.name,
+      photoUrl: data.photoUrl,
+      description: data.description,
+      authorId: authUser.id,
+      categoryId: data.categoryId,
+    },
   })
   return { id: listItem.id, name: listItem.name }
 }


### PR DESCRIPTION
Key changes introduced in PR:
- added category 
- added category to listItem
- added photoUrl to listItem
- updated listItem details page layout
  - made it clear what each field is since the page has multiple pieces of info now

Rules around changes:
- with categories, description is optional
- both category and photo are required fields to create listItem

Notes: 
- i added a migration to easily add categories for testing purposes, but they can be created using the following command
  - `curl -X POST http://localhost:3000/api/category \
     -H "Content-Type: application/x-www-form-urlencoded" \
     -d "name=Seafood&description=Fresh and high-quality fish and shellfish"`

Improvements/fixes:
- on the create listItem form, I forgot the upper title for the category field
- require token to create category
- centralize Category types on FE 

Nest Steps:
- if I were to tackle the bonus part around getting listItems by category I would take the following approach
  - add an optional arg of `categoryId` to listMyItems that filters the results by categoryId if included
  - then on the main page, i would add a filter component that is a category dropdown
    - default to no category selected

https://github.com/user-attachments/assets/0fc4b3b4-4326-4f14-ad10-6871b8ed063f